### PR TITLE
Change working directory to current directory

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 import yaml
 import sys
+import os
 
 from kijiji_scraper.kijiji_scraper import KijijiScraper
 from kijiji_scraper.email_client import EmailClient
@@ -8,6 +9,11 @@ from kijiji_scraper.email_client import EmailClient
 if __name__ == "__main__":
     args = sys.argv
     skip_flag = "-s" in args
+    
+    # Change working directory to current directory
+    abspath = os.path.abspath(__file__)
+    dname = os.path.dirname(abspath)
+    os.chdir(dname)
 
     # Get config values
     with open("config.yaml", "r") as config_file:


### PR DESCRIPTION
When running in crontab, there is an error about the config.yaml file being not found. This is because crontab runs everything in ~/ unlike running the script from the shell directly.

This PR changes the working directory to current directory automatically: https://stackoverflow.com/a/1432949