### PR TITLE
Fix pythonw on win7

### DIFF
--- a/kijiji_scraper/launcher.py
+++ b/kijiji_scraper/launcher.py
@@ -33,6 +33,9 @@ def main():
         init()
         exit(0)
     
+    if sys.executable.endswith("pythonw.exe"):
+         sys.stdout = open(os.devnull, "w")
+    
     # Handle custom config file
     if args.conf:
         filepath=args.conf


### PR DESCRIPTION
On Windows, `pythonw.exe` is for launching GUI/no-UI-at-all scripts, which means that the standard in- and output streams - `sys.stdin, sys.stdout, sys.stderr` are not available

Adding this so `print()` calls and explicit calls to `sys.stdout()` are effectively ignored


https://stackoverflow.com/questions/24835155/pyw-and-pythonw-does-not-run-under-windows-7